### PR TITLE
Serve dashboard view of existing camera feeds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
   compile 'org.opencv:opencv-java:+'
   compile 'org.eclipse.jetty:jetty-server:+'
   compile 'org.eclipse.jetty:jetty-servlet:+'
+  compile 'commons-io:commons-io:+'
   testCompile 'junit:junit:4.12'
 }
 

--- a/src/main/java/FileServer.java
+++ b/src/main/java/FileServer.java
@@ -1,0 +1,44 @@
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.FileUtils;
+
+public class FileServer extends HttpServlet {
+
+  private static final long serialVersionUID = 1L;
+  // Make this customizable
+  private String basePath = "./static";
+
+  @Override
+  public void doGet(HttpServletRequest  request,
+                    HttpServletResponse response) throws IOException {
+
+    String requestedFile = request.getPathInfo();
+
+    // Basic 404 error if the path cannot be parsed
+    if (requestedFile == null) {
+      response.sendError(HttpServletResponse.SC_NOT_FOUND);
+      return;
+    }
+
+    // URL-decode the file name (might contain spaces and on) and prepare file object.
+    File page = new File(basePath, URLDecoder.decode(requestedFile, "UTF-8"));
+    // 404 error if the source is missing
+    if (!page.exists()) {
+      response.sendError(HttpServletResponse.SC_NOT_FOUND);
+      return;
+    }
+
+    response.setContentType("text/html");
+    response.setStatus(HttpServletResponse.SC_OK);
+    response.setContentLengthLong(page.length());
+    PrintWriter out = response.getWriter();
+    String contents = FileUtils.readFileToString(page, StandardCharsets.UTF_8);
+    out.print(contents);
+  }
+}

--- a/src/main/java/FileServer.java
+++ b/src/main/java/FileServer.java
@@ -18,7 +18,7 @@ public class FileServer extends HttpServlet {
   public void doGet(HttpServletRequest  request,
                     HttpServletResponse response) throws IOException {
 
-    String requestedFile = request.getPathInfo();
+    String requestedFile = request.getRequestURI();
 
     // Basic 404 error if the path cannot be parsed
     if (requestedFile == null) {

--- a/src/main/java/HttpManager.java
+++ b/src/main/java/HttpManager.java
@@ -17,6 +17,7 @@ public class HttpManager {
     httpManager.setHandler(router);
     router.addServletWithMapping(VisionTarget.class, "/nav");
     router.addServletWithMapping(FileServer.class, "/debug.html");
+    router.addServletWithMapping(FileServer.class, "/dashboard.html");
   }
 
   public void runServer() {

--- a/src/main/java/HttpManager.java
+++ b/src/main/java/HttpManager.java
@@ -16,6 +16,7 @@ public class HttpManager {
     router = new ServletHandler();
     httpManager.setHandler(router);
     router.addServletWithMapping(VisionTarget.class, "/nav");
+    router.addServletWithMapping(FileServer.class, "/debug.html");
   }
 
   public void runServer() {

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -77,7 +77,8 @@ public class Main {
       NetworkTable.setServerMode();
     } else {
       NetworkTable.setClientMode();
-      NetworkTable.setTeam(982);
+      // NetworkTable.setTeam(982);
+      NetworkTable.setTeam(teamNumber);
     }
 
     NetworkTable.initialize();

--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -98,13 +98,13 @@ public class Main {
     UsbCamera camera = setUsbCamera(0, inputStream);
     // Set the resolution for our camera, since this is over USB
     camera.setResolution(320,240);
-    camera.setFPS(20);
+    camera.setFPS(15);
 
     // If the second USB camera is present, run an isolated video feed for the driver
     MjpegServer rvStream = new MjpegServer("Rear-view Server", 1188);
     UsbCamera rearView = setUsbCamera(1, rvStream);
-    rearView.setResolution(320, 240);
-    rearView.setFPS(20);
+    rearView.setResolution(320,240);
+    rearView.setFPS(15);
 
     // This creates a CvSource to use. This will take in a Mat image that has had OpenCV operations
     CvSource imageSource = new CvSource("CV Image Source", VideoMode.PixelFormat.kMJPEG, 640, 480, 30);

--- a/static/dashboard.html
+++ b/static/dashboard.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+<title>Vision Processing Dashboard</title>
+</head>
+<body>
+<h1 style="margin: auto; width: 50%; text-align:center">Cameras</h1>
+<img src="http://raspberrypi.local:1187/stream.mjpg" style="width:49%">
+<img src="http://raspberrypi.local:1188/stream.mjpg" style="width:49%">
+</body>
+</html>

--- a/static/debug.html
+++ b/static/debug.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+<title>Vision Processing Debugger</title>
+</head>
+<body>
+<h1 style="margin: auto; width: 50%; text-align:center">Debugger</h1>
+<img src="http://raspberrypi.local:1187/stream.mjpg" style="width:49%">
+<img src="http://raspberrypi.local:1186/stream.mjpg" style="width:49%">
+</body>
+</html>


### PR DESCRIPTION
This PR should add a pair of pages to the server, to help make running/testing the camera a bit easier
- http://raspberrypi.local:1181/debug.html
- http://raspberrypi.local:1181/dashboard.html

Both pages should display the video streams side-by-side, scaled to fit the browser width.